### PR TITLE
Feat/#2 spark consumer

### DIFF
--- a/spark_src/processing_raw_data_from_gcs.py
+++ b/spark_src/processing_raw_data_from_gcs.py
@@ -20,6 +20,7 @@ def load_schema(schema_name: str) -> StructType:
     if schema_name not in ['upbit_trade', 'upbit_orderbook']:
         raise Exception("topic name이 적절하지 않습니다. \
                         [upbit_trade, upbit_orderbook] 중에 있어야합니다.")
+    
     if "upbit_trade" == schema_name:
         return StructType([
             StructField("type", StringType(), True),


### PR DESCRIPTION
- raw data gcs로 저장하는 spark 코드의 반복 코드 함수로 처리
- 스트리밍 데이터 write (ob, tr) 반복 코드 함수로 한번에 처리하도록 수정
- 스트리밍 데이터 spark 파일 주석 작성